### PR TITLE
Remove unused dependency `classname`

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "jest-cli": "^0.5.0"
   },
   "dependencies": {
-    "classname": "0.0.0",
     "classnames": "^2.1.3",
     "object-assign": "^4.0.1",
     "react": "^0.13.3"


### PR DESCRIPTION
`classname` library is expressed under `dependencies` but is never used.
Maybe it was mistaken when installed `classnames` library.
